### PR TITLE
Update unsupported Win32 code for Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup environment
       run: |
         pip install -e .
-        pip install Cython
+        pip install Cython==0.29.36
     - run: buildozer --help
     - run: buildozer init
     - name: SDK, NDK and p4a download

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,7 +24,7 @@ jobs:
         source .ci/osx_ci.sh
         arm64_set_path_and_python_version ${{ matrix.python }}
         pip install -e .
-        pip install Cython cookiecutter pbxproj
+        pip install Cython==0.29.36 cookiecutter pbxproj
     - name: Check buildozer installation
       run: |
         source .ci/osx_ci.sh

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -45,18 +45,3 @@ jobs:
       run: docker build --tag=kivy/buildozer .
     - name: Docker run
       run: docker run kivy/buildozer --version
-
-  Python2:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
-    - uses: actions/checkout@v2
-    - name: Try Python 2 install
-      run: |
-        # we don't want the build to fail with the exit 1 so we catch with "||"
-        python2 -m pip install -e . 2> error.log || echo Failing as expected
-        cat error.log
-        grep "Unsupported Python version" error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,6 @@ WORKDIR ${WORK_DIR}
 COPY --chown=user:user . ${SRC_DIR}
 
 # installs buildozer and dependencies
-RUN pip3 install --user --upgrade Cython==0.29.33 wheel pip virtualenv ${SRC_DIR}
+RUN pip3 install --user --upgrade Cython==0.29.36 wheel pip virtualenv ${SRC_DIR}
 
 ENTRYPOINT ["buildozer"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A Dockerfile is available to use buildozer through a Docker environment.
 
 
 ### Example Build with Caching
-Build and keep downloaded SDK and NDK in `~/.buildozer` directory: 
+- Build and keep downloaded SDK and NDK in `~/.buildozer` directory: 
 
       docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcwd kivy/buildozer android debug
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ A Dockerfile is available to use buildozer through a Docker environment.
       docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
 
 
+### Example Build with Caching
+Build and keep downloaded SDK and NDK in `~/.buildozer` directory: 
+
+      docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcwd kivy/buildozer android debug
+
+
 ## Buildozer GitHub action
 
 Use [ArtemSBulgakov/buildozer-action@v1](https://github.com/ArtemSBulgakov/buildozer-action)

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -16,6 +16,7 @@ import codecs
 import textwrap
 import warnings
 from buildozer.jsonstore import JsonStore
+from buildozer.logger import Logger
 from sys import stdout, stderr, exit
 from re import search
 from os.path import join, exists, dirname, realpath, splitext, expanduser
@@ -25,7 +26,6 @@ from copy import copy
 from shutil import copyfile, rmtree, copytree, move, which
 from fnmatch import fnmatch
 
-from pprint import pformat
 import shlex
 import pexpect
 
@@ -36,41 +36,6 @@ try:
 except ImportError:
     # on windows, no fcntl
     fcntl = None
-try:
-    # if installed, it can give color to windows as well
-    import colorama
-    colorama.init()
-
-    RESET_SEQ = colorama.Fore.RESET + colorama.Style.RESET_ALL
-    COLOR_SEQ = lambda x: x  # noqa: E731
-    BOLD_SEQ = ''
-    if sys.platform == 'win32':
-        BLACK = colorama.Fore.BLACK + colorama.Style.DIM
-    else:
-        BLACK = colorama.Fore.BLACK + colorama.Style.BRIGHT
-    RED = colorama.Fore.RED
-    BLUE = colorama.Fore.CYAN
-    USE_COLOR = 'NO_COLOR' not in environ
-
-except ImportError:
-    if sys.platform != 'win32':
-        RESET_SEQ = "\033[0m"
-        COLOR_SEQ = lambda x: "\033[1;{}m".format(30 + x)  # noqa: E731
-        BOLD_SEQ = "\033[1m"
-        BLACK = 0
-        RED = 1
-        BLUE = 4
-        USE_COLOR = 'NO_COLOR' not in environ
-    else:
-        RESET_SEQ = ''
-        COLOR_SEQ = ''
-        BOLD_SEQ = ''
-        RED = BLUE = BLACK = 0
-        USE_COLOR = False
-
-# error, info, debug
-LOG_LEVELS_C = (RED, BLUE, BLACK)
-LOG_LEVELS_T = 'EID'
 SIMPLE_HTTP_SERVER_PORT = 8000
 
 
@@ -101,15 +66,10 @@ class BuildozerCommandException(BuildozerException):
 
 class Buildozer:
 
-    ERROR = 0
-    INFO = 1
-    DEBUG = 2
-
     standard_cmds = ('distclean', 'update', 'debug', 'release',
                      'deploy', 'run', 'serve')
 
     def __init__(self, filename='buildozer.spec', target=None):
-        self.log_level = 2
         self.environ = {}
         self.specfilename = filename
         self.state = None
@@ -123,6 +83,8 @@ class Buildozer:
         self.config.getbooldefault = self._get_config_bool
         self.config.getrawdefault = self._get_config_raw_default
 
+        self.logger = Logger()
+
         if exists(filename):
             self.config.read(filename, "utf-8")
             self.check_configuration_tokens()
@@ -132,8 +94,9 @@ class Buildozer:
         set_config_from_envs(self.config)
 
         try:
-            self.log_level = int(self.config.getdefault(
-                'buildozer', 'log_level', '2'))
+            self.logger.set_level(
+                int(self.config.getdefault(
+                    'buildozer', 'log_level', '2')))
         except Exception:
             pass
 
@@ -163,20 +126,20 @@ class Buildozer:
         if hasattr(self.target, '_build_prepared'):
             return
 
-        self.info('Preparing build')
+        self.logger.info('Preparing build')
 
-        self.info('Check requirements for {0}'.format(self.targetname))
+        self.logger.info('Check requirements for {0}'.format(self.targetname))
         self.target.check_requirements()
 
-        self.info('Install platform')
+        self.logger.info('Install platform')
         self.target.install_platform()
 
-        self.info('Check application requirements')
+        self.logger.info('Check application requirements')
         self.check_application_requirements()
 
         self.check_garden_requirements()
 
-        self.info('Compile platform')
+        self.logger.info('Compile platform')
         self.target.compile_platform()
 
         # flag to prevent multiple build
@@ -200,54 +163,26 @@ class Buildozer:
         self.build_id = int(self.state.get('cache.build_id', '0')) + 1
         self.state['cache.build_id'] = str(self.build_id)
 
-        self.info('Build the application #{}'.format(self.build_id))
+        self.logger.info('Build the application #{}'.format(self.build_id))
         self.build_application()
 
-        self.info('Package the application')
+        self.logger.info('Package the application')
         self.target.build_package()
 
         # flag to prevent multiple build
         self.target._build_done = True
 
     #
-    # Log functions
-    #
-
-    def log(self, level, msg):
-        if level > self.log_level:
-            return
-        if USE_COLOR:
-            color = COLOR_SEQ(LOG_LEVELS_C[level])
-            print(''.join((RESET_SEQ, color, '# ', msg, RESET_SEQ)))
-        else:
-            print('{} {}'.format(LOG_LEVELS_T[level], msg))
-
-    def debug(self, msg):
-        self.log(self.DEBUG, msg)
-
-    def log_env(self, level, env):
-        """dump env into debug logger in readable format"""
-        self.log(level, "ENVIRONMENT:")
-        for k, v in env.items():
-            self.log(level, "    {} = {}".format(k, pformat(v)))
-
-    def info(self, msg):
-        self.log(self.INFO, msg)
-
-    def error(self, msg):
-        self.log(self.ERROR, msg)
-
-    #
     # Internal check methods
     #
 
     def checkbin(self, msg, fn):
-        self.debug('Search for {0}'.format(msg))
+        self.logger.debug('Search for {0}'.format(msg))
         executable_location = which(fn)
         if executable_location:
-            self.debug(' -> found at {0}'.format(executable_location))
+            self.logger.debug(' -> found at {0}'.format(executable_location))
             return realpath(executable_location)
-        self.error('{} not found, please install it.'.format(msg))
+        self.logger.error('{} not found, please install it.'.format(msg))
         exit(1)
 
     def cmd(self, command, **kwargs):
@@ -260,7 +195,7 @@ class Buildozer:
         kwargs.setdefault('stdout', PIPE)
         kwargs.setdefault('stderr', PIPE)
         kwargs.setdefault('close_fds', True)
-        kwargs.setdefault('show_output', self.log_level > 1)
+        kwargs.setdefault('show_output', self.logger.log_level > 1)
 
         show_output = kwargs.pop('show_output')
         get_stdout = kwargs.pop('get_stdout', False)
@@ -272,13 +207,13 @@ class Buildozer:
 
         if not quiet:
             if not sensible:
-                self.debug('Run {0!r}'.format(command))
+                self.logger.debug('Run {0!r}'.format(command))
             else:
                 if isinstance(command, (list, tuple)):
-                    self.debug('Run {0!r} ...'.format(command[0]))
+                    self.logger.debug('Run {0!r} ...'.format(command[0]))
                 else:
-                    self.debug('Run {0!r} ...'.format(command.split()[0]))
-            self.debug('Cwd {}'.format(kwargs.get('cwd')))
+                    self.logger.debug('Run {0!r} ...'.format(command.split()[0]))
+            self.logger.debug('Cwd {}'.format(kwargs.get('cwd')))
 
         # open the process
         if sys.platform == 'win32':
@@ -331,18 +266,18 @@ class Buildozer:
             pass
 
         if process.returncode != 0 and break_on_error:
-            self.error('Command failed: {0}'.format(command))
-            self.log_env(self.ERROR, kwargs['env'])
-            self.error('')
-            self.error('Buildozer failed to execute the last command')
-            if self.log_level <= self.INFO:
-                self.error('If the error is not obvious, please raise the log_level to 2')
-                self.error('and retry the latest command.')
+            self.logger.error('Command failed: {0}'.format(command))
+            self.logger.log_env(self.logger.ERROR, kwargs['env'])
+            self.logger.error('')
+            self.logger.error('Buildozer failed to execute the last command')
+            if self.logger.log_level <= self.logger.INFO:
+                self.logger.error('If the error is not obvious, please raise the log_level to 2')
+                self.logger.error('and retry the latest command.')
             else:
-                self.error('The error might be hidden in the log above this error')
-                self.error('Please read the full log, and search for it before')
-                self.error('raising an issue with buildozer itself.')
-            self.error('In case of a bug report, please add a full log with log_level = 2')
+                self.logger.error('The error might be hidden in the log above this error')
+                self.logger.error('Please read the full log, and search for it before')
+                self.logger.error('raising an issue with buildozer itself.')
+            self.logger.error('In case of a bug report, please add a full log with log_level = 2')
             raise BuildozerCommandException()
 
         if ret_stdout:
@@ -362,7 +297,7 @@ class Buildozer:
 
         # prepare the process
         kwargs.setdefault('env', env)
-        kwargs.setdefault('show_output', self.log_level > 1)
+        kwargs.setdefault('show_output', self.logger.log_level > 1)
         sensible = kwargs.pop('sensible', False)
         show_output = kwargs.pop('show_output')
 
@@ -370,17 +305,17 @@ class Buildozer:
             kwargs['logfile'] = codecs.getwriter('utf8')(stdout.buffer)
 
         if not sensible:
-            self.debug('Run (expect) {0!r}'.format(command))
+            self.logger.debug('Run (expect) {0!r}'.format(command))
         else:
-            self.debug('Run (expect) {0!r} ...'.format(command.split()[0]))
+            self.logger.debug('Run (expect) {0!r} ...'.format(command.split()[0]))
 
-        self.debug('Cwd {}'.format(kwargs.get('cwd')))
+        self.logger.debug('Cwd {}'.format(kwargs.get('cwd')))
         return pexpect.spawnu(shlex.join(command), **kwargs)
 
     def check_configuration_tokens(self):
         '''Ensure the spec file is 'correct'.
         '''
-        self.info('Check configuration tokens')
+        self.logger.info('Check configuration tokens')
         self.migrate_configuration_tokens()
         get = self.config.getdefault
         errors = []
@@ -412,7 +347,7 @@ class Buildozer:
             if o not in ("landscape", "portrait", "landscape-reverse", "portrait-reverse"):
                 adderror(f'[app] "{o}" is not a valid  value for "orientation"')
         if errors:
-            self.error('{0} error(s) found in the buildozer.spec'.format(
+            self.logger.error('{0} error(s) found in the buildozer.spec'.format(
                 len(errors)))
             for error in errors:
                 print(error)
@@ -435,14 +370,14 @@ class Buildozer:
                 value = config.get("app", entry_old)
                 config.set("app", entry_new, value)
                 config.remove_option("app", entry_old)
-                self.error("In section [app]: {} is deprecated, rename to {}!".format(
+                self.logger.error("In section [app]: {} is deprecated, rename to {}!".format(
                     entry_old, entry_new))
 
     def check_build_layout(self):
         '''Ensure the build (local and global) directory layout and files are
         ready.
         '''
-        self.info('Ensure build layout')
+        self.logger.info('Ensure build layout')
 
         if not exists(self.specfilename):
             print('No {0} found in the current directory. Abandon.'.format(
@@ -483,7 +418,7 @@ class Buildozer:
                         target_available_packages]
 
         if requirements and hasattr(sys, 'real_prefix'):
-            e = self.error
+            e = self.logger.error
             e('virtualenv is needed to install pure-Python modules, but')
             e('virtualenv does not support nesting, and you are running')
             e('buildozer in one. Please run buildozer outside of a')
@@ -495,7 +430,7 @@ class Buildozer:
             exists(self.applibs_dir) and
             self.state.get('cache.applibs', '') == requirements
         ):
-            self.debug('Application requirements already installed, pass')
+            self.logger.debug('Application requirements already installed, pass')
             return
 
         # recreate applibs
@@ -511,7 +446,7 @@ class Buildozer:
 
     def _install_application_requirement(self, module):
         self._ensure_virtualenv()
-        self.debug('Install requirement {} in virtualenv'.format(module))
+        self.logger.debug('Install requirement {} in virtualenv'.format(module))
         self.cmd(
             ["pip", "install", f"--target={self.applibs_dir}", module],
             env=self.env_venv,
@@ -556,13 +491,13 @@ class Buildozer:
     def mkdir(self, dn):
         if exists(dn):
             return
-        self.debug('Create directory {0}'.format(dn))
+        self.logger.debug('Create directory {0}'.format(dn))
         makedirs(dn)
 
     def rmdir(self, dn):
         if not exists(dn):
             return
-        self.debug('Remove directory and subdirectory {}'.format(dn))
+        self.logger.debug('Remove directory and subdirectory {}'.format(dn))
         rmtree(dn)
 
     def file_matches(self, patterns):
@@ -580,9 +515,9 @@ class Buildozer:
         if cwd:
             source = join(cwd, source)
             target = join(cwd, target)
-        self.debug('Rename {0} to {1}'.format(source, target))
+        self.logger.debug('Rename {0} to {1}'.format(source, target))
         if not os.path.isdir(os.path.dirname(target)):
-            self.error(('Rename {0} to {1} fails because {2} is not a '
+            self.logger.error(('Rename {0} to {1} fails because {2} is not a '
                         'directory').format(source, target, target))
         move(source, target)
 
@@ -590,7 +525,7 @@ class Buildozer:
         if cwd:
             source = join(cwd, source)
             target = join(cwd, target)
-        self.debug('Copy {0} to {1}'.format(source, target))
+        self.logger.debug('Copy {0} to {1}'.format(source, target))
         copyfile(source, target)
 
     def file_extract(self, archive, cwd=None):
@@ -629,7 +564,7 @@ class Buildozer:
             copyfile(src, dest)
 
     def clean_platform(self):
-        self.info('Clean the platform build directory')
+        self.logger.info('Clean the platform build directory')
         if not exists(self.platform_dir):
             return
         rmtree(self.platform_dir)
@@ -651,7 +586,7 @@ class Buildozer:
         if self.file_exists(filename):
             unlink(filename)
 
-        self.debug('Downloading {0}'.format(url))
+        self.logger.debug('Downloading {0}'.format(url))
         urlretrieve(url, filename, report_hook)
         return filename
 
@@ -685,7 +620,7 @@ class Buildozer:
                         'Unable to find capture version in {0}\n'
                         ' (looking for `{1}`)'.format(fn, regex))
                 version = match.groups()[0]
-                self.debug('Captured version: {0}'.format(version))
+                self.logger.debug('Captured version: {0}'.format(version))
                 return version
 
         raise Exception('Missing version or version.regex + version.filename')
@@ -713,7 +648,7 @@ class Buildozer:
         exclude_patterns = [pat.lower() for pat in exclude_patterns]
         include_patterns = [pat.lower() for pat in include_patterns]
 
-        self.debug('Copy application source from {}'.format(source_dir))
+        self.logger.debug('Copy application source from {}'.format(source_dir))
 
         rmtree(self.app_dir)
 
@@ -792,7 +727,7 @@ class Buildozer:
                 self.mkdir(dfn)
 
                 # copy!
-                self.debug('Copy {0}'.format(sfn))
+                self.logger.debug('Copy {0}'.format(sfn))
                 copyfile(sfn, rfn)
 
     def _copy_application_libs(self):
@@ -815,7 +750,7 @@ class Buildozer:
         data = header + data
         with open(main_py, 'wb') as fd:
             fd.write(data)
-        self.info('Patched service/main.py to include applibs')
+        self.logger.info('Patched service/main.py to include applibs')
 
     def namify(self, name):
         '''Return a "valid" name from a name with lot of invalid chars
@@ -909,9 +844,6 @@ class Buildozer:
                 yield target, m
             except NotImplementedError:
                 pass
-            except:
-                raise
-                pass
 
     def usage(self):
         print('Usage:')
@@ -982,7 +914,7 @@ class Buildozer:
             arg = args.pop(0)
 
             if arg in ('-v', '--verbose'):
-                self.log_level = 2
+                self.logger.set_level(2)
 
             elif arg in ('-h', '--help'):
                 self.usage()
@@ -1056,7 +988,7 @@ class Buildozer:
         print("Warning: Your ndk, sdk and all other cached packages will be"
               " removed. Continue? (y/n)")
         if sys.stdin.readline().lower()[0] == 'y':
-            self.info('Clean the global build directory')
+            self.logger.info('Clean the global build directory')
             if not exists(self.global_buildozer_dir):
                 return
             rmtree(self.global_buildozer_dir)
@@ -1069,14 +1001,14 @@ class Buildozer:
         more than the user intends.
         '''
         if self.user_build_dir is not None:
-            self.error(
+            self.logger.error(
                 ('Failed: build_dir is specified as {} in the buildozer config. `appclean` will '
                  'not attempt to delete files in a user-specified build directory.').format(self.user_build_dir))
         elif exists(self.buildozer_dir):
-            self.info('Deleting {}'.format(self.buildozer_dir))
+            self.logger.info('Deleting {}'.format(self.buildozer_dir))
             rmtree(self.buildozer_dir)
         else:
-            self.error('{} already deleted, skipping.'.format(self.buildozer_dir))
+            self.logger.error('{} already deleted, skipping.'.format(self.buildozer_dir))
 
     def cmd_help(self, *args):
         '''Show the Buildozer help.

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -22,7 +22,7 @@ from os.path import join, exists, dirname, realpath, splitext, expanduser
 from subprocess import Popen, PIPE, TimeoutExpired
 from os import environ, unlink, walk, sep, listdir, makedirs
 from copy import copy
-from shutil import copyfile, rmtree, copytree, move
+from shutil import copyfile, rmtree, copytree, move, which
 from fnmatch import fnmatch
 
 from pprint import pformat
@@ -243,13 +243,10 @@ class Buildozer:
 
     def checkbin(self, msg, fn):
         self.debug('Search for {0}'.format(msg))
-        if exists(fn):
-            return realpath(fn)
-        for dn in environ['PATH'].split(':'):
-            rfn = realpath(join(dn, fn))
-            if exists(rfn):
-                self.debug(' -> found at {0}'.format(rfn))
-                return rfn
+        executable_location = which(fn)
+        if executable_location:
+            self.debug(' -> found at {0}'.format(executable_location))
+            return realpath(executable_location)
         self.error('{} not found, please install it.'.format(msg))
         exit(1)
 

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -323,7 +323,7 @@ android.allow_backup = True
 # (str) python-for-android specific commit to use, defaults to HEAD, must be within p4a.branch
 #p4a.commit = HEAD
 
-# (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
+# (str) python-for-android git clone directory
 #p4a.source_dir =
 
 # (str) The directory in which python-for-android should look for your own build recipes (if any)

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -1,3 +1,8 @@
+# This .spec config file tells Buildozer an app's requirements for being built.
+#
+# It largely follows the syntax of an .ini file.
+# See the end of the file for more details and warnings about common mistakes.
+
 [app]
 
 # (str) Title of your application
@@ -447,3 +452,37 @@ warn_on_root = 1
 #    Then, invoke the command line with the "demo" profile:
 #
 #buildozer --profile demo android debug
+
+### Notes about using this file: ###
+#
+#   Buildozer uses a variant of Python's ConfigSpec to read this file.
+#   For the syntax, including interpolations, see
+#       https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
+#
+#   Warning: Comments cannot be used "inline" - i.e.
+#       [app]
+#       title = My Application # This is not a comment, it is part of the title.
+#
+#   Warning: Indented text is treated as a multiline string - i.e.
+#       [app]
+#       title = My Application
+#          package.name = myapp # This is all part of the title.
+#
+#   Buildozer's .spec files have some additional features:
+#
+#   Buildozer supports lists - i.e.
+#       [app]
+#       source.include_exts = py,png,jpg
+#       #                     ^ This is a list.
+#
+#       [app:source.include_exts]
+#       py
+#       png
+#       jpg
+#       # ^ This is an alternative syntax for a list.
+#
+#   Buildozer's option names are case-sensitive, unlike most .ini files.
+#
+#   Buildozer supports overriding options through environment variables.
+#   Name an environment variable as SECTION_OPTION to override a value in a .spec
+#   file.

--- a/buildozer/logger.py
+++ b/buildozer/logger.py
@@ -1,0 +1,87 @@
+"""
+Logger
+======
+
+Logger implementation used by Buildozer.
+
+Supports colored output, where available.
+"""
+
+from os import environ
+from pprint import pformat
+import sys
+
+try:
+    # if installed, it can give color to Windows as well
+    import colorama
+
+    colorama.init()
+except ImportError:
+    colorama = None
+
+# set color codes
+if colorama:
+    RESET_SEQ = colorama.Fore.RESET + colorama.Style.RESET_ALL
+    COLOR_SEQ = lambda x: x  # noqa: E731
+    BOLD_SEQ = ""
+    if sys.platform == "win32":
+        BLACK = colorama.Fore.BLACK + colorama.Style.DIM
+    else:
+        BLACK = colorama.Fore.BLACK + colorama.Style.BRIGHT
+    RED = colorama.Fore.RED
+    BLUE = colorama.Fore.CYAN
+    USE_COLOR = "NO_COLOR" not in environ
+elif sys.platform != "win32":
+    RESET_SEQ = "\033[0m"
+    COLOR_SEQ = lambda x: "\033[1;{}m".format(30 + x)  # noqa: E731
+    BOLD_SEQ = "\033[1m"
+    BLACK = 0
+    RED = 1
+    BLUE = 4
+    USE_COLOR = "NO_COLOR" not in environ
+else:
+    RESET_SEQ = ""
+    COLOR_SEQ = ""
+    BOLD_SEQ = ""
+    RED = BLUE = BLACK = 0
+    USE_COLOR = False
+
+
+class Logger:
+    ERROR = 0
+    INFO = 1
+    DEBUG = 2
+
+    LOG_LEVELS_C = (RED, BLUE, BLACK)  # Map levels to colors
+    LOG_LEVELS_T = "EID"  # error, info, debug
+
+    log_level = ERROR
+
+    def log(self, level, msg):
+        if level > self.log_level:
+            return
+        if USE_COLOR:
+            color = COLOR_SEQ(Logger.LOG_LEVELS_C[level])
+            print("".join((RESET_SEQ, color, "# ", msg, RESET_SEQ)))
+        else:
+            print("{} {}".format(Logger.LOG_LEVELS_T[level], msg))
+
+    def debug(self, msg):
+        self.log(self.DEBUG, msg)
+
+    def info(self, msg):
+        self.log(self.INFO, msg)
+
+    def error(self, msg):
+        self.log(self.ERROR, msg)
+
+    def log_env(self, level, env):
+        """dump env into logger in readable format"""
+        self.log(level, "ENVIRONMENT:")
+        for k, v in env.items():
+            self.log(level, "    {} = {}".format(k, pformat(v)))
+
+    @classmethod
+    def set_level(cls, level):
+        """set minimum threshold for log messages"""
+        cls.log_level = level

--- a/buildozer/scripts/client.py
+++ b/buildozer/scripts/client.py
@@ -6,6 +6,7 @@ Main Buildozer client
 
 import sys
 from buildozer import Buildozer, BuildozerCommandException, BuildozerException
+from buildozer.logger import Logger
 
 
 def main():
@@ -16,7 +17,7 @@ def main():
         # the command failed.
         sys.exit(1)
     except BuildozerException as error:
-        Buildozer().error('%s' % error)
+        Logger().error('%s' % error)
         sys.exit(1)
 
 

--- a/buildozer/specparser.py
+++ b/buildozer/specparser.py
@@ -1,0 +1,128 @@
+"""
+    A customised ConfigParser, suitable for buildozer.spec.
+
+    Supports
+        - list values
+            - either comma separated, or in their own [section:option] section.
+        - environment variable overrides of values
+            - overrides applied at construction.
+        - case-sensitive keys
+        - "No values" are permitted.
+"""
+
+from configparser import ConfigParser
+from os import environ
+
+
+class SpecParser(ConfigParser):
+    def __init__(self, *args, **kwargs):
+        # Allow "no value" options to better support lists.
+        super().__init__(*args, allow_no_value=True, **kwargs)
+
+    def optionxform(self, optionstr: str) -> str:
+        """Override method that canonicalizes keys to retain
+        case sensitivity."""
+        return optionstr
+
+    # Override all the readers to apply env variables over the top.
+
+    def read(self, filenames, encoding=None):
+        super().read(filenames, encoding)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    def read_file(self, f, source=None):
+        super().read_file(f, source)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    def read_string(self, string, source="<string>"):
+        super().read_string(string, source)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    def read_dict(self, dictionary, source="<dict>"):
+        super().read_dict(dictionary, source)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    # Add new getters
+
+    def getlist(
+        self, section, token, default=None, with_values=False, strip=True,
+        section_sep="=", split_char=","
+    ):
+        """Return a list of strings.
+
+        They can be found as the list of options in a [section:token] section,
+        or in a [section], under the a option, as a comma-separated (or
+        split_char-separated) list,
+        Failing that, default is returned (as is).
+
+        If with_values is set, and they are in a [section:token] section,
+        the option values are included with the option key,
+        separated by section_sep
+        """
+
+        # if a section:token is defined, let's use the content as a list.
+        l_section = "{}:{}".format(section, token)
+        if self.has_section(l_section):
+            values = self.options(l_section)
+            if with_values:
+                return [
+                    "{}{}{}".format(key, section_sep, self.get(l_section, key))
+                    for key in values
+                ]
+            return values if not strip else [x.strip() for x in values]
+        values = self.getdefault(section, token, None)
+        if values is None:
+            return default
+        values = values.split(split_char)
+        if not values:
+            return default
+        return values if not strip else [x.strip() for x in values]
+
+    def getlistvalues(self, section, token, default=None):
+        """ Convenience function.
+            Deprecated - call getlist directly."""
+        return self.getlist(section, token, default, with_values=True)
+
+    def getdefault(self, section, token, default=None):
+        """
+        Convenience function.
+        Deprecated - call get directly."""
+        return self.get(section, token, fallback=default)
+
+    def getbooldefault(self, section, token, default=False):
+        """
+        Convenience function.
+        Deprecated - call getboolean directly."""
+        return self.getboolean(section, token, fallback=default)
+
+    # Handle env vars.
+
+    def _override_config_from_envs(self):
+        """Takes a ConfigParser, and checks every section/token for an
+        environment variable of the form SECTION_TOKEN, with any dots
+        replaced by underscores. If the variable exists, sets the config
+        variable to the env value.
+        """
+        for section in self.sections():
+            for token in self.options(section):
+                self._override_config_token_from_env(section, token)
+
+    def _override_config_token_from_env(self, section, token):
+        """Given a config section and token, checks for an appropriate
+        environment variable. If the variable exists, sets the config entry to
+        its value.
+
+        The environment variable checked is of the form SECTION_TOKEN, all
+        upper case, with any dots replaced by underscores.
+
+        """
+        env_var_name = "_".join(
+            item.upper().replace(".", "_") for item in (section, token)
+        )
+        env_var = environ.get(env_var_name)
+        if env_var is not None:
+            self.set(section, token, env_var)

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -2,6 +2,8 @@ from sys import exit
 import os
 from os.path import join
 
+from buildozer.logger import Logger
+
 
 def no_config(f):
     f.__no_config = True
@@ -14,16 +16,17 @@ class Target:
         self.build_mode = 'debug'
         self.artifact_format = 'apk'
         self.platform_update = False
+        self.logger = Logger()
 
     def check_requirements(self):
         pass
 
     def check_configuration_tokens(self, errors=None):
         if errors:
-            self.buildozer.info('Check target configuration tokens')
-            self.buildozer.error(
+            self.logger.info('Check target configuration tokens')
+            self.logger.error(
                 '{0} error(s) found in the buildozer.spec'.format(
-                len(errors)))
+                    len(errors)))
             for error in errors:
                 print(error)
             exit(1)
@@ -49,7 +52,7 @@ class Target:
 
     def run_commands(self, args):
         if not args:
-            self.buildozer.error('Missing target command')
+            self.logger.error('Missing target command')
             self.buildozer.usage()
             exit(1)
 
@@ -68,7 +71,7 @@ class Target:
                 last_command.append(arg)
             else:
                 if not last_command:
-                    self.buildozer.error('Argument passed without a command')
+                    self.logger.error('Argument passed without a command')
                     self.buildozer.usage()
                     exit(1)
                 last_command.append(arg)
@@ -80,7 +83,7 @@ class Target:
         for item in result:
             command, args = item[0], item[1:]
             if not hasattr(self, 'cmd_{0}'.format(command)):
-                self.buildozer.error('Unknown command {0}'.format(command))
+                self.logger.error('Unknown command {0}'.format(command))
                 exit(1)
 
             func = getattr(self, 'cmd_{0}'.format(command))
@@ -106,7 +109,7 @@ class Target:
         self.buildozer.build()
 
     def cmd_release(self, *args):
-        error = self.buildozer.error
+        error = self.logger.error
         self.buildozer.prepare_for_build()
         if self.buildozer.config.get("app", "package.domain") == "org.test":
             error("")

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1432,8 +1432,12 @@ class TargetAndroid(Target):
         serial = self.serials[0:]
         if not serial:
             return
-        filters = self.buildozer.config.getrawdefault(
-            "app", "android.logcat_filters", "", section_sep=":", split_char=" ")
+        filters = self.buildozer.config.getlist(
+            "app",
+            "android.logcat_filters",
+            default="",
+            section_sep=":",
+            strip=False)
         filters = " ".join(filters)
         self.buildozer.environ['ANDROID_SERIAL'] = serial[0]
         extra_args = []

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -10,8 +10,8 @@ from tests.targets.utils import (
     init_buildozer,
     patch_buildozer_checkbin,
     patch_buildozer_cmd,
-    patch_buildozer_error,
     patch_buildozer_file_exists,
+    patch_logger_error,
 )
 
 
@@ -195,7 +195,7 @@ class TestTargetIos:
         target.ios_dir = "/ios/dir"
         # fmt: off
         with patch_target_ios("_unlock_keychain") as m_unlock_keychain, \
-             patch_buildozer_error() as m_error, \
+             patch_logger_error() as m_error, \
              mock.patch("buildozer.targets.ios.TargetIos.load_plist_from_file") as m_load_plist_from_file, \
              mock.patch("buildozer.targets.ios.TargetIos.dump_plist_to_file") as m_dump_plist_to_file, \
              patch_buildozer_cmd() as m_cmd:

--- a/tests/targets/utils.py
+++ b/tests/targets/utils.py
@@ -22,8 +22,8 @@ def patch_buildozer_file_exists():
     return patch_buildozer("file_exists")
 
 
-def patch_buildozer_error():
-    return patch_buildozer("error")
+def patch_logger_error():
+    return mock.patch("buildozer.logger.Logger.error")
 
 
 def default_specfile_path():

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,53 @@
+import unittest
+from buildozer.logger import Logger
+
+from io import StringIO
+from unittest import mock
+
+
+class TestLogger(unittest.TestCase):
+    def test_log_print(self):
+        """
+        Checks logger prints different info depending on log level.
+        """
+        logger = Logger()
+
+        # Test ERROR Level
+        Logger.set_level(0)
+        assert logger.log_level == logger.ERROR
+
+        # at this level, only error messages should be printed
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger.debug("debug message")
+            logger.info("info message")
+            logger.error("error message")
+        # using `in` keyword rather than `==` because of color prefix/suffix
+        assert "debug message" not in mock_stdout.getvalue()
+        assert "info message" not in mock_stdout.getvalue()
+        assert "error message" in mock_stdout.getvalue()
+
+        # Test INFO Level
+        Logger.set_level(1)
+        assert logger.log_level == logger.INFO
+
+        # at this level, debug messages should not be printed
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger.debug("debug message")
+            logger.info("info message")
+            logger.error("error message")
+        # using `in` keyword rather than `==` because of color prefix/suffix
+        assert "debug message" not in mock_stdout.getvalue()
+        assert "info message" in mock_stdout.getvalue()
+        assert "error message" in mock_stdout.getvalue()
+
+        # sets log level to 2 in the spec file
+        Logger.set_level(2)
+        assert logger.log_level == logger.DEBUG
+        # at this level all message types should be printed
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger.debug("debug message")
+            logger.info("info message")
+            logger.error("error message")
+        assert "debug message" in mock_stdout.getvalue()
+        assert "info message" in mock_stdout.getvalue()
+        assert "error message" in mock_stdout.getvalue()

--- a/tests/test_specparser.py
+++ b/tests/test_specparser.py
@@ -1,0 +1,172 @@
+from os import environ
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from buildozer.specparser import SpecParser
+
+
+class TestSpecParser(unittest.TestCase):
+    def test_overrides(self):
+        environ["SECTION_1_ATTRIBUTE_1"] = "Env Value"
+
+        # Test as a string.
+        sp = SpecParser()
+        sp.read_string(
+            """
+            [section.1]
+            attribute.1=String Value
+            """
+        )
+        assert sp.get("section.1", "attribute.1") == "Env Value"
+
+        # Test as a dict
+        sp = SpecParser()
+        sp.read_dict({"section.1": {"attribute.1": "Dict Value"}})
+        assert sp.get("section.1", "attribute.1") == "Env Value"
+
+        with TemporaryDirectory() as temp_dir:
+            spec_path = Path(temp_dir) / "test.spec"
+            with open(spec_path, "w") as spec_file:
+                spec_file.write(
+                    """
+                    [section.1]
+                    attribute.1=File Value
+                    """
+                )
+
+            # Test as a file
+            sp = SpecParser()
+            with open(spec_path, "r") as spec_file:
+                sp.read_file(spec_file)
+            assert sp.get("section.1", "attribute.1") == "Env Value"
+
+            # Test as a list of filenames
+            sp = SpecParser()
+            sp.read([spec_path])
+            assert sp.get("section.1", "attribute.1") == "Env Value"
+
+    def test_new_getters(self):
+        sp = SpecParser()
+        sp.read_string(
+            """
+                [section1]
+                attribute1=1
+                attribute2=red, white, blue
+                attribute3=True
+                attribute5=large/medium/small
+
+                [section2:attribute4]
+                red=1
+                amber=
+                green=3
+
+
+            """
+        )
+
+        assert sp.get("section1", "attribute1") == "1"
+        assert sp.getlist("section1", "attribute2") == ["red", "white", "blue"]
+        assert sp.getlist("section1", "attribute2", strip=False) == [
+            "red",
+            " white",
+            " blue",
+        ]
+
+        assert sp.getlist("section2", "attribute4") == [
+            "red",
+            "amber",
+            "green",
+        ]
+        # Test with_values and section_sep
+        assert sp.getlistvalues("section2", "attribute4") == [
+            "red=1",
+            "amber=",
+            "green=3",
+        ]
+        assert sp.getlist(
+            "section2", "attribute4", with_values=True, section_sep=":"
+        ) == [
+            "red:1",
+            "amber:",
+            "green:3",
+        ]
+        # Test split_char
+        assert sp.getlist("section1", "attribute5", with_values=True) == [
+            "large/medium/small",
+        ]
+        assert sp.getlist(
+            "section1", "attribute5", with_values=True, split_char="/"
+        ) == [
+            "large",
+            "medium",
+            "small",
+        ]
+
+        assert sp.getbooldefault("section1", "attribute3") is True
+
+    def test_case_sensitivity(self):
+        sp = SpecParser()
+        sp.read_string(
+            """
+                [section1]
+                attribute1=a
+                Attribute1=A
+            """
+        )
+
+        assert sp.get("section1", "attribute1") == "a"
+        assert sp.get("section1", "Attribute1") == "A"
+
+    def test_controversial_cases(self):
+        """Some aspects of the config syntax seem to cause confusion.
+        This shows what the code is *specified* to do, which might not be
+        expected.
+        """
+        sp = SpecParser()
+        sp.read_string(
+            """
+                [section]
+                    # Comments can be indented.
+                option1=a  # This is not considered a comment
+                option2=this is
+                   a multiline string (not a list!)
+                   # This is considered a comment.
+                   this_is_not_an_option=it is still part of the multiline
+                option3=this, is, one, way, of, representing, lists
+
+                [section:option4]
+                this_is
+                another_way
+                # This is a comment.
+                of # This is not a comment.
+                representing=4
+                lists
+            """
+        )
+
+        assert (
+            sp.get("section", "option1") ==
+            "a  # This is not considered a comment"
+        )
+        assert (
+            sp.get("section", "option2") ==
+            "this is\na multiline string (not a list!)\n"
+            "this_is_not_an_option=it is still part of the multiline"
+        )
+        assert sp.getlist("section", "option3") == [
+            "this",
+            "is",
+            "one",
+            "way",
+            "of",
+            "representing",
+            "lists",
+        ]
+        assert sp.getlist("section", "option4") == [
+            "this_is",
+            "another_way",
+            "of # This is not a comment.",
+            "representing",
+            "lists",
+        ]


### PR DESCRIPTION
These changes are necessary-but-nowhere-near-sufficient for eventual support of generating Kivy Android files from native Windows. They have no visible effect on currently supported platforms.

- Support experimental access to Android target on Win32, via an (unpublished) environment variable.
- Support sdkmanager installer having a different name (.bat extension) on Windows.
- Correct trivial formatting error in Exception text.
- Update references from _winreg to winreg (Built-in module was renamed in Python 3.)
- Correct download URL to Android NDK for the Windows platform